### PR TITLE
Moved default role file creation outside destination node loop so we only write file once per service config

### DIFF
--- a/cmd/refresh-uids-from-ferry/utils.go
+++ b/cmd/refresh-uids-from-ferry/utils.go
@@ -78,7 +78,7 @@ func getAllAccountsFromConfig() []string {
 		for role := range viper.GetStringMap(roleConfigPath) {
 			accountConfigPath := roleConfigPath + "." + role + ".account"
 			account := viper.GetString(accountConfigPath)
-			log.WithField("account", account).Debug("Found account")
+			exeLogger.WithField("account", account).Debug("Found account")
 			s = append(s, account)
 		}
 	}

--- a/cmd/token-push/funcOpts.go
+++ b/cmd/token-push/funcOpts.go
@@ -48,7 +48,7 @@ func getDefaultRoleFileDestinationTemplate(serviceConfigPath string) string {
 	if !viper.IsSet(defaultRoleFileDestinationTmplPath) {
 		return "/tmp/default_role_{{.Experiment}}_{{.DesiredUID}}" // Default role file destination template
 	}
-	return defaultRoleFileDestinationTmplPath
+	return viper.GetString(defaultRoleFileDestinationTmplPath)
 }
 
 // getFileCopierOptionsFromConfig gets the fileCopierOptions from the configuration.  If fileCopierOptions

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -464,7 +464,7 @@ func run(ctx context.Context) error {
 				worker.SetDesiredUID(uid),
 				worker.SetNodes(viper.GetStringSlice(serviceConfigPath+".destinationNodes")),
 				worker.SetAccount(viper.GetString(serviceConfigPath+".account")),
-				worker.SetSupportedExtrasKeyValue(worker.DefaultRoleFileTemplate, defaultRoleFileDestinationTemplate),
+				worker.SetSupportedExtrasKeyValue(worker.DefaultRoleFileDestinationTemplate, defaultRoleFileDestinationTemplate),
 				worker.SetSupportedExtrasKeyValue(worker.FileCopierOptions, fileCopierOptions),
 			)
 			if err != nil {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -25,14 +25,14 @@ type supportedExtrasKey int
 
 const (
 	// DefaultRoleFileTemplate is a key to store the value of the default role file template in the Config.Extras map
-	DefaultRoleFileTemplate supportedExtrasKey = iota
+	DefaultRoleFileDestinationTemplate supportedExtrasKey = iota
 	FileCopierOptions
 )
 
 func (s supportedExtrasKey) String() string {
 	switch s {
-	case DefaultRoleFileTemplate:
-		return "DefaultRoleFileTemplate"
+	case DefaultRoleFileDestinationTemplate:
+		return "DefaultRoleFileDestinationTemplate"
 	case FileCopierOptions:
 		return "FileCopierOptions"
 	default:
@@ -124,4 +124,17 @@ func (c *Config) RegisterUnpingableNode(node string) {
 func (c *Config) IsNodeUnpingable(node string) bool {
 	_, ok := c.unPingableNodes.Load(node)
 	return ok
+}
+
+// GetDefaultRoleFileTemplateValueFromExtras retrieves the default role file template value from the worker.Config,
+// and asserts that it is a string.  Callers should check the bool return value to make sure the type assertion
+// passes, for example:
+//
+//	c := worker.NewConfig( // various options )
+//	// set the default role file template in here
+//	tmplString, ok := GetDefaultRoleFileTemplateValueFromExtras(c)
+//	if !ok { // handle missing or incorrect value }
+func GetDefaultRoleFileDestinationTemplateValueFromExtras(c *Config) (string, bool) {
+	defaultRoleFileDestinationTemplateString, ok := c.Extras[DefaultRoleFileDestinationTemplate].(string)
+	return defaultRoleFileDestinationTemplateString, ok
 }

--- a/internal/worker/pushTokensWorker.go
+++ b/internal/worker/pushTokensWorker.go
@@ -131,6 +131,7 @@ func PushTokensWorker(ctx context.Context, chans ChannelsForWorkers) {
 				serviceLogger.WithField("filename", defaultRoleFile.Name()).Error("Error writing default role string to temporary file.  Please clean up manually.  Will not push the default role file")
 				return
 			}
+			serviceLogger.WithField("filename", defaultRoleFile.Name()).Debug("Wrote default role file to transfer to nodes")
 
 			sourceFilename := fmt.Sprintf("/tmp/vt_u%s-%s", currentUID, sc.Service.Name())
 			destinationFilenames := []string{
@@ -206,7 +207,7 @@ func PushTokensWorker(ctx context.Context, chans ChannelsForWorkers) {
 				}(destinationNode)
 				nodeWg.Wait()
 
-				// Send the tempfile to the destination node.  If we fail here, don't count this as an error
+				// Send the default role file to the destination node.  If we fail here, don't count this as an error
 				pushContext, pushCancel := context.WithTimeout(ctx, pushTimeout)
 				defer pushCancel()
 				if err := pushToNode(pushContext, sc, defaultRoleFile.Name(), destinationNode, defaultRoleFileDestinationFilename); err != nil {

--- a/internal/worker/pushTokensWorker_test.go
+++ b/internal/worker/pushTokensWorker_test.go
@@ -14,9 +14,9 @@ func TestSetDefaultRoleFileTemplateValueInExtras(t *testing.T) {
 	testTemplateString := "testtemplate"
 	c, _ := NewConfig(
 		s,
-		SetSupportedExtrasKeyValue(DefaultRoleFileTemplate, testTemplateString),
+		SetSupportedExtrasKeyValue(DefaultRoleFileDestinationTemplate, testTemplateString),
 	)
-	if result := c.Extras[DefaultRoleFileTemplate]; result != testTemplateString {
+	if result := c.Extras[DefaultRoleFileDestinationTemplate]; result != testTemplateString {
 		t.Errorf("Wrong template string stored.  Expected %s, got %s", testTemplateString, result)
 	}
 }
@@ -51,8 +51,8 @@ func TestGetDefaultRoleFileTemplateValueFromExtras(t *testing.T) {
 		t.Run(test.description,
 			func(t *testing.T) {
 				c, _ := NewConfig(s)
-				c.Extras[DefaultRoleFileTemplate] = test.stored
-				result, check := GetDefaultRoleFileTemplateValueFromExtras(c)
+				c.Extras[DefaultRoleFileDestinationTemplate] = test.stored
+				result, check := GetDefaultRoleFileDestinationTemplateValueFromExtras(c)
 				if check != test.expectedCheck {
 					t.Errorf("Type assertion failed.  Expected type assertion check to return %t, got %t", test.expectedCheck, check)
 				}
@@ -106,8 +106,8 @@ func TestParseDefaultRoleFileTemplateFromConfig(t *testing.T) {
 	for _, test := range goodTestCases {
 		t.Run(test.description,
 			func(t *testing.T) {
-				c.Extras[DefaultRoleFileTemplate] = test.stored
-				result, err := parseDefaultRoleFileTemplateFromConfig(c)
+				c.Extras[DefaultRoleFileDestinationTemplate] = test.stored
+				result, err := parseDefaultRoleFileDestinationTemplateFromConfig(c)
 				if err == nil && test.err != nil {
 					t.Errorf("Expected error of type %T, got nil instead", test.expected)
 				}


### PR DESCRIPTION
Moved default role file creation outside destination node loop so we only write file once per service config

Closes #32 