### PR TITLE
Refactor notifications library

### DIFF
--- a/cmd/token-push/notificationsManager.go
+++ b/cmd/token-push/notificationsManager.go
@@ -61,7 +61,11 @@ func registerServiceNotificationsChan(ctx context.Context, s service.Service, da
 		em.NotificationMinimum = viper.GetInt("errorCountToSendMessage")
 		return nil
 	}
-	funcOpts = append(funcOpts, setNotificationMinimum)
+	setEmail := func(em *notifications.ServiceEmailManager) error {
+		em.Email = e
+		return nil
+	}
+	funcOpts = append(funcOpts, setNotificationMinimum, setEmail)
 
 	if database != nil {
 		setDB := func(em *notifications.ServiceEmailManager) error {

--- a/internal/notifications/admin.go
+++ b/internal/notifications/admin.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/shreyb/managed-tokens/internal/db"
 )
@@ -107,6 +108,8 @@ func NewAdminNotificationManager(ctx context.Context, opts ...AdminNotificationM
 	return a
 }
 
+// runAdminNotificationHandler handles the routing and counting of errors that result from a
+// Notification being sent on the AdminNotificationManager's ReceiveChan
 func runAdminNotificationHandler(ctx context.Context, a *AdminNotificationManager, adminChan chan<- Notification, allServiceCounts map[string]*serviceErrorCounts, shouldTrackErrorCounts bool) {
 	funcLogger := log.WithField("caller", "runAdminNotificationHandler")
 
@@ -191,109 +194,126 @@ func determineIfShouldTrackErrorCounts(ctx context.Context, a *AdminNotification
 // SendAdminNotifications sends admin messages via email and Slack that have been collected in adminErrors. It expects a valid template file
 // configured at adminTemplatePath
 func SendAdminNotifications(ctx context.Context, operation string, adminTemplatePath string, isTest bool, sendMessagers ...SendMessager) error {
-	var wg sync.WaitGroup
-	var existsSendError bool
 	funcLogger := log.WithField("caller", "notifications.SendAdminNotifications")
 
+	// Let all adminErrors writers finish updating adminErrors
 	adminErrors.writerCount.Wait()
 	funcLogger.Debug("adminErrors is finalized")
 
 	// No errors - only send slack message saying we tested.  If there are no errors, we don't send emails
-	if syncMapLength(adminErrors.errorsMap) == 0 {
+	if adminErrorsIsEmpty() {
 		if isTest {
-			slackMessages := make([]*slackMessage, 0)
-			slackMsgText := "Test run completed successfully"
-			for _, sm := range sendMessagers {
-				if messager, ok := sm.(*slackMessage); ok {
-					slackMessages = append(slackMessages, messager)
-				}
-			}
-			for _, slackMessage := range slackMessages {
-				if slackErr := SendMessage(ctx, slackMessage, slackMsgText); slackErr != nil {
-					funcLogger.Error("Failed to send slack message")
-					return slackErr
-				}
+			if err := sendSlackNoErrorTestMessages(ctx, sendMessagers); err != nil {
+				funcLogger.Error("Error sending admin notifications saying there were no errors in test mode")
+				return err
 			}
 		}
 		funcLogger.Debug("No errors to send")
 		return nil
 	}
 
-	// If there are errors, prepare the long-form and abridged messages
-	adminErrorsMapFinal := prepareAdminErrorsForFullMessage()
-	setupErrorsCombined, pushErrorsCombined := prepareAbridgedAdminSlices()
-
-	// Prepare the full and abridged messages
-	timestamp := time.Now().Format(time.RFC822)
-	fullMessageStruct := struct {
-		Timestamp           string
-		Operation           string
-		AdminErrors         map[string]AdminDataFinal
-		SetupErrorsCombined []string
-		PushErrorsCombined  []string
-		Abridged            bool
-	}{
-		Timestamp:           timestamp,
-		Operation:           operation,
-		AdminErrors:         adminErrorsMapFinal,
-		SetupErrorsCombined: setupErrorsCombined,
-		PushErrorsCombined:  pushErrorsCombined,
-		Abridged:            false,
-	}
-	abridgedMessageStruct := struct {
-		Timestamp           string
-		Operation           string
-		AdminErrors         map[string]AdminDataFinal
-		SetupErrorsCombined []string
-		PushErrorsCombined  []string
-		Abridged            bool
-	}{
-		Timestamp:           timestamp,
-		Operation:           operation,
-		AdminErrors:         adminErrorsMapFinal,
-		SetupErrorsCombined: setupErrorsCombined,
-		PushErrorsCombined:  pushErrorsCombined,
-		Abridged:            true,
-	}
-
-	fullMessage, err := prepareMessageFromTemplate(strings.NewReader(adminErrorsTemplate), fullMessageStruct)
+	fullMessage, abridgedMessage, err := prepareFullAndAbridgedMessages(operation)
 	if err != nil {
-		funcLogger.Errorf("Could not prepare full admin message from template: %s", err)
-		return err
-	}
-	abridgedMessage, err := prepareMessageFromTemplate(strings.NewReader(adminErrorsTemplate), abridgedMessageStruct)
-	if err != nil {
-		funcLogger.Errorf("Could not prepare abridged admin message from template: %s", err)
+		funcLogger.Errorf("Could not prepare full or abridged admin message from template: %s", err)
 		return err
 	}
 
 	// Run SendMessage on all configured sendMessagers
+	g := new(errgroup.Group)
 	for _, sm := range sendMessagers {
-		wg.Add(1)
-		go func(sm SendMessager) {
-			defer wg.Done()
+		sm := sm
+		g.Go(func() error {
+			var messageToSend, logEnding string
 			switch sm.(type) {
 			case *email:
-				// Send long-form message
-				if err := SendMessage(ctx, sm, fullMessage); err != nil {
-					existsSendError = true
-					funcLogger.Error("Failed to send admin email")
-				}
+				messageToSend = fullMessage
+				logEnding = "admin email"
 			case *slackMessage:
-				// Send abridged message
-				if err := SendMessage(ctx, sm, abridgedMessage); err != nil {
-					existsSendError = true
-					funcLogger.Error("Failed to send slack message")
-				}
+				messageToSend = abridgedMessage
+				logEnding = "slack message"
 			default:
-				funcLogger.Error("Unsupported SendMessager")
+				err := errors.New("unsupported SendMessager")
+				funcLogger.Error(err)
+				return err
 			}
-		}(sm)
+			if err := SendMessage(ctx, sm, messageToSend); err != nil {
+				funcLogger.Errorf("Failed to send %s", logEnding)
+				return err
+			}
+			return nil
+		})
 	}
-	wg.Wait()
 
-	if existsSendError {
+	if err := g.Wait(); err != nil {
 		return errors.New("sending admin notifications failed.  Please see logs")
+	}
+
+	return nil
+}
+
+func prepareFullAndAbridgedMessages(operation string) (fullMessage string, abridgedMessage string, err error) {
+	funcLogger := log.WithFields(log.Fields{
+		"caller":    "notifications.prepareFullAndAbridgedMessages",
+		"operation": operation,
+	})
+	timestamp := time.Now().Format(time.RFC822)
+
+	// If there are errors, prepare the long-form and abridged messages
+	// Prepare the full and abridged messages
+	adminErrorsMapFinal := prepareAdminErrorsForFullMessage()
+	fullMessageStruct := struct {
+		Timestamp   string
+		Operation   string
+		AdminErrors map[string]AdminDataFinal
+		Abridged    bool
+	}{
+		Timestamp:   timestamp,
+		Operation:   operation,
+		AdminErrors: adminErrorsMapFinal,
+		Abridged:    false,
+	}
+	fullMessage, err = prepareMessageFromTemplate(strings.NewReader(adminErrorsTemplate), fullMessageStruct)
+	if err != nil {
+		funcLogger.Errorf("Could not prepare full admin message from template: %s", err)
+		return "", "", err
+	}
+
+	setupErrorsCombined, pushErrorsCombined := prepareAbridgedAdminSlices()
+	abridgedMessageStruct := struct {
+		Timestamp           string
+		Operation           string
+		SetupErrorsCombined []string
+		PushErrorsCombined  []string
+		Abridged            bool
+	}{
+		Timestamp:           timestamp,
+		Operation:           operation,
+		SetupErrorsCombined: setupErrorsCombined,
+		PushErrorsCombined:  pushErrorsCombined,
+		Abridged:            true,
+	}
+	abridgedMessage, err = prepareMessageFromTemplate(strings.NewReader(adminErrorsTemplate), abridgedMessageStruct)
+	if err != nil {
+		funcLogger.Errorf("Could not prepare abridged admin message from template: %s", err)
+		return "", "", err
+	}
+	return fullMessage, abridgedMessage, nil
+}
+
+func sendSlackNoErrorTestMessages(ctx context.Context, sendMessagers []SendMessager) error {
+	funcLogger := log.WithField("caller", "sendSlackNoErrorTestMessages")
+	slackMessages := make([]*slackMessage, 0)
+	slackMsgText := "Test run completed successfully"
+	for _, sm := range sendMessagers {
+		if messager, ok := sm.(*slackMessage); ok {
+			slackMessages = append(slackMessages, messager)
+		}
+	}
+	for _, slackMessage := range slackMessages {
+		if slackErr := SendMessage(ctx, slackMessage, slackMsgText); slackErr != nil {
+			funcLogger.Error("Failed to send slack message")
+			return slackErr
+		}
 	}
 	return nil
 }
@@ -342,14 +362,14 @@ func addErrorToAdminErrors(n Notification) {
 	switch nValue := n.(type) {
 	// For *setupErrors, store or append the setupError text to the appropriate field
 	case *setupError:
-		if actual, loaded := adminErrors.errorsMap.LoadOrStore(
+		if data, loaded := adminErrors.errorsMap.LoadOrStore(
 			nValue.service,
 			&adminData{
 				SetupErrors: []string{nValue.message},
 			},
 		); loaded {
 			// Service already has *adminData stored
-			if accumulatedAdminData, ok := actual.(*adminData); !ok {
+			if accumulatedAdminData, ok := data.(*adminData); !ok {
 				funcLogger.Panic("Invalid data stored in admin errors map.")
 			} else {
 				// Just append the newest setup error to the slice
@@ -358,7 +378,7 @@ func addErrorToAdminErrors(n Notification) {
 		}
 	// This case is a bit more complicated, since the pushErrors are stored in a sync.Map
 	case *pushError:
-		actual, loaded := adminErrors.errorsMap.LoadOrStore(
+		data, loaded := adminErrors.errorsMap.LoadOrStore(
 			// Roughly an initialization of the PushErrors sync.Map
 			nValue.service,
 			&adminData{
@@ -366,10 +386,10 @@ func addErrorToAdminErrors(n Notification) {
 			},
 		)
 		if loaded {
-			if adminData, ok := actual.(*adminData); !ok {
+			if accumulatedAdminData, ok := data.(*adminData); !ok {
 				funcLogger.Panic("Invalid data stored in admin errors map.")
 			} else {
-				adminData.PushErrors.Store(nValue.node, nValue.message)
+				accumulatedAdminData.PushErrors.Store(nValue.node, nValue.message)
 			}
 		} else {
 			// At this point, since we didn't wrap the LoadOrStore call in an if-contraction (if <expression>; loaded {})
@@ -418,9 +438,10 @@ type adminDataUnsync struct {
 // adminErrorsToAdminDataUnsync translates the accumulated adminErrors.errorsMap into a map[string]adminDataUnsync so that
 // we have easier access to the structure of the data
 func adminErrorsToAdminDataUnsync() map[string]adminDataUnsync {
+	funcLogger := log.WithField("caller", "notifications.adminErrorsToAdminDataUnsync")
+
 	adminErrorsMap := make(map[string]*adminData)
 	adminErrorsMapUnsync := make(map[string]adminDataUnsync)
-	funcLogger := log.WithField("caller", "notifications.adminErrorsToAdminDataUnsync")
 	// 1.  Write adminErrors from sync.Map to Map called adminErrorsMap
 	adminErrors.errorsMap.Range(func(service, aData any) bool {
 		s, ok := service.(string)
@@ -468,3 +489,6 @@ func adminErrorsToAdminDataUnsync() map[string]adminDataUnsync {
 func (a *adminData) isEmpty() bool {
 	return ((len(a.SetupErrors) == 0) && (syncMapLength(&a.PushErrors) == 0))
 }
+
+// adminErrorsIsEmpty checks to see if there are no adminErrors
+func adminErrorsIsEmpty() bool { return syncMapLength(adminErrors.errorsMap) == 0 }

--- a/internal/notifications/admin.go
+++ b/internal/notifications/admin.go
@@ -144,6 +144,7 @@ func runAdminNotificationHandler(ctx context.Context, a *AdminNotificationManage
 						shouldSend = adjustErrorCountsByServiceAndDirectNotification(n, allServiceCounts[n.GetService()], a.NotificationMinimum)
 						if !shouldSend {
 							funcLogger.Debug("Error count less than error limit.  Not sending notification.")
+							continue
 						}
 					}
 					if shouldSend {

--- a/internal/notifications/db.go
+++ b/internal/notifications/db.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"sync"
 
 	"github.com/shreyb/managed-tokens/internal/db"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // errorCount is an integer that keeps track of whether its value was changed from when it was initially loaded
@@ -34,72 +34,61 @@ type serviceErrorCounts struct {
 // setErrorCountsByService queries the db.ManagedTokensDatabase to load the prior errorCounts for a given service
 func setErrorCountsByService(ctx context.Context, service string, database *db.ManagedTokensDatabase) (*serviceErrorCounts, bool) {
 	funcLogger := log.WithField("service", service)
+
 	// Only track errors if we have a valid ManagedTokensDatabase
 	if database == nil {
 		return nil, false
 	}
 
 	ec := &serviceErrorCounts{}
-	tChan := make(chan error, 2)
-	var tWg sync.WaitGroup
+	g := new(errgroup.Group)
 
-	// Check for setupError counts
-	tWg.Add(1)
-	go func() {
-		defer tWg.Done()
-		var err error
-		setupErrorData, err := database.GetSetupErrorsInfoByService(ctx, service)
-		defer func() {
-			tChan <- err
-		}()
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				funcLogger.Debug("No setupError information for service.  Assuming there are no prior errors")
-				err = nil
-			} else {
-				funcLogger.Error("Could not get setupError information. Please inspect database")
-			}
-			return
-		}
-		ec.setupErrors.value = setupErrorData.Count()
-	}()
-
-	// Check for pushErrorCounts
-	tWg.Add(1)
-	go func() {
-		defer tWg.Done()
-		var err error
-		ec.pushErrors = make(map[string]errorCount)
-		pushErrorData, err := database.GetPushErrorsInfoByService(ctx, service)
-		defer func() {
-			tChan <- err
-		}()
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				funcLogger.Debug("No pushError information for service.  Assuming there are no prior errors")
-				err = nil
-			} else {
-				funcLogger.Error("Could not get pushError information.  Please inspect database")
-			}
-			return
-		}
-		for _, datum := range pushErrorData {
-			errorCountVal := errorCount{value: datum.Count()}
-			ec.pushErrors[datum.Node()] = errorCountVal
-		}
-	}()
-
-	tWg.Wait() // Wait until we finish sending any errors with regard to getting error count info
-	close(tChan)
+	g.Go(func() error {
+		return populateServiceSetupErrorCountFromDatabase(ctx, service, database, ec)
+	})
+	g.Go(func() error {
+		return populateServicePushErrorCountFromDatabase(ctx, service, database, ec)
+	})
 
 	// Listen on tChan to see if we got any errors getting error counts from ManagedTokensDatabase
-	for err := range tChan {
-		if err != nil {
-			funcLogger.Error("Error getting error info from database.  Will not track errors")
-			return nil, false
-		}
+	if err := g.Wait(); err != nil {
+		funcLogger.Error("Error getting error info from database.  Will not track errors")
+		return nil, false
 	}
 	return ec, true
+}
+
+func populateServiceSetupErrorCountFromDatabase(ctx context.Context, service string, database *db.ManagedTokensDatabase, ec *serviceErrorCounts) error {
+	funcLogger := log.WithField("caller", "populateServiceSetupErrorCountFromDatabase")
+	setupErrorData, err := database.GetSetupErrorsInfoByService(ctx, service)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			funcLogger.Debug("No setupError information for service.  Assuming there are no prior errors")
+			return nil
+		}
+		funcLogger.Error("Could not get setupError information. Please inspect database")
+		return err
+	}
+	ec.setupErrors.value = setupErrorData.Count()
+	return nil
+}
+func populateServicePushErrorCountFromDatabase(ctx context.Context, service string, database *db.ManagedTokensDatabase, ec *serviceErrorCounts) error {
+	funcLogger := log.WithField("caller", "populateServicePushErrorCountFromDatabase")
+	ec.pushErrors = make(map[string]errorCount)
+	pushErrorData, err := database.GetPushErrorsInfoByService(ctx, service)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			funcLogger.Debug("No pushError information for service.  Assuming there are no prior errors")
+			return nil
+		}
+		funcLogger.Error("Could not get pushError information.  Please inspect database")
+		return err
+	}
+	for _, datum := range pushErrorData {
+		errorCountVal := errorCount{value: datum.Count()}
+		ec.pushErrors[datum.Node()] = errorCountVal
+	}
+	return nil
 }
 
 // setupErrorCount is a type that encapsulates a service and the number of setupErrors registered for that service.  It implements db.SetupErrorCount

--- a/internal/notifications/db.go
+++ b/internal/notifications/db.go
@@ -176,13 +176,10 @@ func saveErrorCountsInDatabase(ctx context.Context, service string, database *db
 // and the configured minimum threshhold for sending messages, will return whether or not that Notification should be flagged to be sent to the stakeholder
 func adjustErrorCountsByServiceAndDirectNotification(n Notification, ec *serviceErrorCounts, errorCountToSendMessage int) (sendNotification bool) {
 	adjustCount := func(count int) (newCount int, shouldSendNotification bool) {
-		// Increment count
 		newCount = count + 1
 		if newCount >= errorCountToSendMessage {
-			// Reset the counter to 0, allow for notification to be staged for sending
 			newCount = 0
 			shouldSendNotification = true
-			// We're under our threshhold for sending notifications, so sendNotification remains false
 		}
 		return newCount, shouldSendNotification
 	}

--- a/internal/notifications/db.go
+++ b/internal/notifications/db.go
@@ -32,12 +32,12 @@ type serviceErrorCounts struct {
 }
 
 // setErrorCountsByService queries the db.ManagedTokensDatabase to load the prior errorCounts for a given service
-func setErrorCountsByService(ctx context.Context, service string, database *db.ManagedTokensDatabase) (*serviceErrorCounts, bool) {
+func setErrorCountsByService(ctx context.Context, service string, database *db.ManagedTokensDatabase) (*serviceErrorCounts, error) {
 	funcLogger := log.WithField("service", service)
 
 	// Only track errors if we have a valid ManagedTokensDatabase
 	if database == nil {
-		return nil, false
+		return nil, errors.New("no database to query")
 	}
 
 	ec := &serviceErrorCounts{}
@@ -53,9 +53,9 @@ func setErrorCountsByService(ctx context.Context, service string, database *db.M
 	// Listen on tChan to see if we got any errors getting error counts from ManagedTokensDatabase
 	if err := g.Wait(); err != nil {
 		funcLogger.Error("Error getting error info from database.  Will not track errors")
-		return nil, false
+		return nil, err
 	}
-	return ec, true
+	return ec, nil
 }
 
 func populateServiceSetupErrorCountFromDatabase(ctx context.Context, service string, database *db.ManagedTokensDatabase, ec *serviceErrorCounts) error {

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -70,5 +70,4 @@ func (e *email) sendMessage(ctx context.Context, message string) error {
 		}
 		return err
 	}
-
 }

--- a/internal/notifications/serviceEmailManager.go
+++ b/internal/notifications/serviceEmailManager.go
@@ -11,13 +11,15 @@ import (
 	"github.com/shreyb/managed-tokens/internal/db"
 )
 
-// EmailManager is simply a channel on which Notification objects can be sent and received
+// ServiceEmailManager contains all the information needed to receive Notifications for services and ensure they get sent in the
+// correct email
 type ServiceEmailManager struct {
 	ReceiveChan         chan Notification
 	Service             string
 	Email               *email
 	Database            *db.ManagedTokensDatabase
 	NotificationMinimum int
+	wg                  *sync.WaitGroup
 }
 
 type ServiceEmailManagerOption func(*ServiceEmailManager) error
@@ -35,6 +37,7 @@ func NewServiceEmailManager(ctx context.Context, wg *sync.WaitGroup, service str
 	em := &ServiceEmailManager{
 		Service:     service,
 		ReceiveChan: make(chan Notification),
+		wg:          wg,
 	}
 	for _, opt := range opts {
 		if err := opt(em); err != nil {
@@ -42,24 +45,33 @@ func NewServiceEmailManager(ctx context.Context, wg *sync.WaitGroup, service str
 		}
 	}
 
-	// Get our previous error information for this service
-	ec, trackErrorCounts := setErrorCountsByService(ctx, em.Service, em.Database)
+	ec, shouldTrackErrorCounts := setErrorCountsByService(ctx, em.Service, em.Database) // Get our previous error information for this service
 
-	// Set up the various admin channels needed
 	adminChan := make(chan Notification)
 	startAdminErrorAdder(adminChan)
+	runServiceNotificationHandler(ctx, em, adminChan, ec, shouldTrackErrorCounts)
+
+	return em
+}
+
+// runServiceNotificationHandler concurrently handles the routing and counting of errors that result from a Notification being sent
+// on the ServiceEmailManager's ReceiveChan.
+func runServiceNotificationHandler(ctx context.Context, em *ServiceEmailManager, adminChan chan Notification, ec *serviceErrorCounts, shouldTrackErrorCounts bool) {
+	funcLogger := log.WithFields(log.Fields{
+		"caller":  "notifications.runServiceNotificationHandler",
+		"service": em.Service,
+	})
 
 	// Start listening for new notifications
 	go func() {
 		serviceErrorsTable := make(map[string]string, 0)
-		defer wg.Done()
+		defer em.wg.Done()
 		defer close(adminChan)
 		for {
 			select {
 			case <-ctx.Done():
 				if err := ctx.Err(); err == context.DeadlineExceeded {
 					funcLogger.Error("Timeout exceeded in notification Manager")
-
 				} else {
 					funcLogger.Error(err)
 				}
@@ -68,52 +80,69 @@ func NewServiceEmailManager(ctx context.Context, wg *sync.WaitGroup, service str
 			case n, chanOpen := <-em.ReceiveChan:
 				// Channel is closed --> save errors to database and send notifications
 				if !chanOpen {
-					if trackErrorCounts {
+					if shouldTrackErrorCounts {
 						if err := saveErrorCountsInDatabase(ctx, em.Service, em.Database, ec); err != nil {
 							funcLogger.Error("Error saving new error counts in database.  Please investigate")
 						}
 					}
-					if len(serviceErrorsTable) > 0 {
-						tableString := aggregateServicePushErrors(serviceErrorsTable)
-						msg, err := prepareServiceEmail(ctx, tableString, e)
-						if err != nil {
-							funcLogger.Error("Error preparing service email for sending")
-						}
-						if err = SendMessage(ctx, e, msg); err != nil {
-							funcLogger.Error("Error sending email")
-						}
-					}
+					sendServiceEmailIfErrors(ctx, serviceErrorsTable, em)
 					return
 				}
+
 				// Channel is open: direct the message as needed
-				log.WithFields(log.Fields{
-					"service": n.GetService(),
-					"message": n.GetMessage(),
-				}).Debug("Received notification message")
+				funcLogger.WithField("message", n.GetMessage()).Debug("Received notification message")
 				shouldSend := true
-				if trackErrorCounts {
+				if shouldTrackErrorCounts {
 					shouldSend = adjustErrorCountsByServiceAndDirectNotification(n, ec, em.NotificationMinimum)
 					if !shouldSend {
 						log.WithField("service", n.GetService()).Debug("Error count less than error limit.  Not sending notification")
+						continue
 					}
 				}
 				if shouldSend {
-					msg := "Error counts either not tracked or exceeded error limit.  Sending notification"
-					if nValue, ok := n.(*pushError); ok {
-						serviceErrorsTable[nValue.node] = n.GetMessage()
-						log.WithFields(log.Fields{
-							"service": nValue.service,
-							"node":    nValue.node,
-						}).Debug(msg)
-					} else {
-						log.WithField("service", n.GetService()).Debug(msg)
-					}
+					addPushErrorNotificationToServiceErrorsTable(n, serviceErrorsTable)
 					adminChan <- n
 				}
 			}
 		}
 	}()
-	return em
+}
+
+func addPushErrorNotificationToServiceErrorsTable(n Notification, serviceErrorsTable map[string]string) {
+	// Note that we ONLY send push errors to the stakeholders.  Only admins will get all Notifications.
+	funcLogger := log.WithFields(log.Fields{
+		"caller":  "notifications.addPushErrorNotificationToServiceErrorsTable",
+		"service": n.GetService(),
+	})
+
+	msg := "Error counts either not tracked or exceeded error limit.  Sending notification"
+	if nValue, ok := n.(*pushError); ok {
+		serviceErrorsTable[nValue.node] = n.GetMessage()
+		funcLogger.WithField("node", nValue.node).Debug(msg)
+		return
+	}
+	funcLogger.Debug(msg)
+}
+
+func sendServiceEmailIfErrors(ctx context.Context, serviceErrorsTable map[string]string, em *ServiceEmailManager) {
+	funcLogger := log.WithFields(log.Fields{
+		"caller":  "notifications.sendServiceEmailIfErrors",
+		"service": em.Service,
+	})
+
+	if len(serviceErrorsTable) == 0 {
+		funcLogger.Debug("No errors to send for service")
+		return
+	}
+
+	tableString := aggregateServicePushErrors(serviceErrorsTable)
+	msg, err := prepareServiceEmail(ctx, tableString, em.Email)
+	if err != nil {
+		funcLogger.Error("Error preparing service email for sending")
+	}
+	if err = SendMessage(ctx, em.Email, msg); err != nil {
+		funcLogger.Error("Error sending email")
+	}
 }
 
 // prepareServiceEmail sets a passed-in email object's templateStruct field to the passed in errorTable, and returns a string that contains

--- a/internal/notifications/tableUtils.go
+++ b/internal/notifications/tableUtils.go
@@ -20,6 +20,12 @@ func PrepareTableStringFromMap(m map[string]string, helpMessage string, header [
 	return finalTable
 }
 
+// mapStringMapStringErrorToTable takes a map[string]map[string]string and generates a table using the provided header slice
+func mapStringStringToTable(myMap map[string]string, header []string) string {
+	data := wrapMapToTableData(myMap)
+	return createBasicTable(data, header)
+}
+
 // createBasicTable creates a basic table from data in the form of a [][]string object with a header
 func createBasicTable(data [][]string, header []string) string {
 	var b strings.Builder
@@ -29,12 +35,6 @@ func createBasicTable(data [][]string, header []string) string {
 	table.SetBorder(false)
 	table.Render()
 	return b.String()
-}
-
-// mapStringMapStringErrorToTable takes a map[string]map[string]string and generates a table using the provided header slice
-func mapStringStringToTable(myMap map[string]string, header []string) string {
-	data := wrapMapToTableData(myMap)
-	return createBasicTable(data, header)
 }
 
 // wrapMapToTableData wraps MapToTable by taking a map, getting its value, and then passing that to MapToTable with the proper initialization parameters.  This or a function like it should be used by external APIs as opposed to MapToTable.

--- a/internal/notifications/template.go
+++ b/internal/notifications/template.go
@@ -39,7 +39,6 @@ func prepareMessageFromTemplate(templateReader io.Reader, tmplStruct any) (strin
 	}
 
 	var tmplBuilder strings.Builder
-
 	if err = messageTemplate.Execute(&tmplBuilder, tmplStruct); err != nil {
 		log.Errorf("Failed to execute message template: %s", err)
 		return "", errExecuteTemplate


### PR DESCRIPTION
Closes #31 

Simplify a lot of the logic in the notifications library so it's easier to troubleshoot.  Also eliminated some of the complicated concurrency.