### PR TITLE
Add holdoff mechanism for concurrent condor_vault_storer calls

### DIFF
--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -573,8 +573,8 @@ func run(ctx context.Context) error {
 	startCondorVault := time.Now()
 	condorVaultChans := startServiceConfigWorkerForProcessing(ctx, worker.StoreAndGetTokenWorker, serviceConfigs, "vaultstorer")
 
-	// To avoid kerberos cache race conditions, condor_vault_storer must be run sequentially, so we'll wait until all are done,
-	// remove any service configs that we couldn't get tokens for from serviceConfigs, and then begin transferring to nodes
+	// Wait until all workers are done, remove any service configs that we couldn't get tokens for from Configs,
+	// and then begin transferring to nodes
 	failedVaultConfigs := removeFailedServiceConfigs(condorVaultChans, serviceConfigs)
 	for _, failure := range failedVaultConfigs {
 		exeLogger.WithField("service", failure.Service.Name()).Error("Failed to obtain vault token.  Will not try to push vault token to service nodes")

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -496,6 +496,7 @@ func run(ctx context.Context) error {
 			keytabPath := cmdUtils.GetKeytabFromConfiguration(serviceConfigPath)
 			defaultRoleFileDestinationTemplate := getDefaultRoleFileDestinationTemplate(serviceConfigPath)
 			fileCopierOptions := getFileCopierOptionsFromConfig(serviceConfigPath)
+			vaultTokenStoreHoldoffFunc := getVaultTokenStoreHoldoffFuncOpt(s)
 			c, err := worker.NewConfig(
 				s,
 				worker.SetCommandEnvironment(
@@ -512,6 +513,7 @@ func run(ctx context.Context) error {
 				worker.SetAccount(viper.GetString(serviceConfigPath+".account")),
 				worker.SetSupportedExtrasKeyValue(worker.DefaultRoleFileDestinationTemplate, defaultRoleFileDestinationTemplate),
 				worker.SetSupportedExtrasKeyValue(worker.FileCopierOptions, fileCopierOptions),
+				vaultTokenStoreHoldoffFunc,
 			)
 			if err != nil {
 				funcLogger.Error("Could not create config for service")

--- a/internal/vaultToken/vaultToken.go
+++ b/internal/vaultToken/vaultToken.go
@@ -125,7 +125,7 @@ func getDefaultVaultTokenLocation() (string, error) {
 }
 
 func validateServiceVaultToken(serviceName string) error {
-	funcLogger := log.WithField("serviceName", serviceName)
+	funcLogger := log.WithField("service", serviceName)
 	vaultTokenFilename, err := getCondorVaultTokenLocation(serviceName)
 	if err != nil {
 		funcLogger.Error("Could not get default vault token location")

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -19,27 +19,6 @@ type unPingableNodes struct {
 	sync.Map
 }
 
-// supportedExtrasKey is an enumerated key for the Config.Extras map.  Callers wishing to store values
-// in the Config.Extras map should use a SupportedExtrasKey as the key
-type supportedExtrasKey int
-
-const (
-	// DefaultRoleFileTemplate is a key to store the value of the default role file template in the Config.Extras map
-	DefaultRoleFileDestinationTemplate supportedExtrasKey = iota
-	FileCopierOptions
-)
-
-func (s supportedExtrasKey) String() string {
-	switch s {
-	case DefaultRoleFileDestinationTemplate:
-		return "DefaultRoleFileDestinationTemplate"
-	case FileCopierOptions:
-		return "FileCopierOptions"
-	default:
-		return "unsupported extras key"
-	}
-}
-
 // Config is a mega struct containing all the information the workers need to have or pass onto lower level funcs.
 type Config struct {
 	service.Service
@@ -125,17 +104,4 @@ func (c *Config) RegisterUnpingableNode(node string) {
 func (c *Config) IsNodeUnpingable(node string) bool {
 	_, ok := c.unPingableNodes.Load(node)
 	return ok
-}
-
-// GetDefaultRoleFileTemplateValueFromExtras retrieves the default role file template value from the worker.Config,
-// and asserts that it is a string.  Callers should check the bool return value to make sure the type assertion
-// passes, for example:
-//
-//	c := worker.NewConfig( // various options )
-//	// set the default role file template in here
-//	tmplString, ok := GetDefaultRoleFileTemplateValueFromExtras(c)
-//	if !ok { // handle missing or incorrect value }
-func GetDefaultRoleFileDestinationTemplateValueFromExtras(c *Config) (string, bool) {
-	defaultRoleFileDestinationTemplateString, ok := c.Extras[DefaultRoleFileDestinationTemplate].(string)
-	return defaultRoleFileDestinationTemplateString, ok
 }

--- a/internal/worker/configFuncOpts.go
+++ b/internal/worker/configFuncOpts.go
@@ -77,11 +77,3 @@ func SetVaultServer(value string) func(*Config) error {
 		return nil
 	}
 }
-
-// SetSupportedExtrasKeyValue returns a func(*Config) that sets the value for the given supportedExtraskey in the Extras map
-func SetSupportedExtrasKeyValue(key supportedExtrasKey, value any) func(*Config) error {
-	return func(c *Config) error {
-		c.Extras[key] = value
-		return nil
-	}
-}

--- a/internal/worker/supportedExtrasKey.go
+++ b/internal/worker/supportedExtrasKey.go
@@ -1,0 +1,58 @@
+package worker
+
+// supportedExtrasKey is an enumerated key for the Config.Extras map.  Callers wishing to store values
+// in the Config.Extras map should use a SupportedExtrasKey as the key
+type supportedExtrasKey int
+
+const (
+	// DefaultRoleFileTemplate is a key to store the value of the default role file template in the Config.Extras map
+	DefaultRoleFileDestinationTemplate supportedExtrasKey = iota
+	FileCopierOptions
+	VaultTokenStoreHoldoff
+)
+
+func (s supportedExtrasKey) String() string {
+	switch s {
+	case DefaultRoleFileDestinationTemplate:
+		return "DefaultRoleFileDestinationTemplate"
+	case FileCopierOptions:
+		return "FileCopierOptions"
+	case VaultTokenStoreHoldoff:
+		return "VaultTokenStoreHoldoff"
+	default:
+		return "unsupported extras key"
+	}
+}
+
+// SetSupportedExtrasKeyValue returns a func(*Config) that sets the value for the given supportedExtraskey in the Extras map
+func SetSupportedExtrasKeyValue(key supportedExtrasKey, value any) func(*Config) error {
+	return func(c *Config) error {
+		c.Extras[key] = value
+		return nil
+	}
+}
+
+// GetDefaultRoleFileTemplateValueFromExtras retrieves the default role file template value from the worker.Config,
+// and asserts that it is a string.  Callers should check the bool return value to make sure the type assertion
+// passes, for example:
+//
+//	c := worker.NewConfig( // various options )
+//	// set the default role file template in here
+//	tmplString, ok := GetDefaultRoleFileTemplateValueFromExtras(c)
+//	if !ok { // handle missing or incorrect value }
+func GetDefaultRoleFileDestinationTemplateValueFromExtras(c *Config) (string, bool) {
+	defaultRoleFileDestinationTemplateString, ok := c.Extras[DefaultRoleFileDestinationTemplate].(string)
+	return defaultRoleFileDestinationTemplateString, ok
+}
+
+// GetVaultTokenStoreHoldoff returns the value from the Config for the Extras VaultTokenStoreHoldoff key.
+// It also returns a bool, ok, indicating whether this value should be used or not.
+func GetVaultTokenStoreHoldoff(c *Config) (holdoff bool, ok bool) {
+	holdoff, ok = c.Extras[VaultTokenStoreHoldoff].(bool)
+	return holdoff, ok
+}
+
+// SetVaultTokenStoreHoldoff returns a func(*Config) that sets the VaultTokenStoreHoldoff Extras key of the *Config to true
+func SetVaultTokenStoreHoldoff() func(*Config) error {
+	return SetSupportedExtrasKeyValue(VaultTokenStoreHoldoff, true)
+}

--- a/internal/worker/supportedExtrasKey_test.go
+++ b/internal/worker/supportedExtrasKey_test.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/shreyb/managed-tokens/internal/service"
+)
+
+func TestGetVaultTokenStoreHoldoff(t *testing.T) {
+	config, _ := NewConfig(service.NewService("test_service"), SetSupportedExtrasKeyValue(VaultTokenStoreHoldoff, true))
+	holdoff, ok := GetVaultTokenStoreHoldoff(config)
+	if !ok {
+		t.Errorf("Should have a holdoff value")
+		return
+	}
+	if !holdoff {
+		t.Errorf("Expected to have a holdoff value of true.  Got false")
+	}
+}
+
+func TestSetVaultTokenStoreHoldoff(t *testing.T) {
+	config, _ := NewConfig(service.NewService("test_service"), SetVaultTokenStoreHoldoff())
+	val, ok := config.Extras[VaultTokenStoreHoldoff]
+	if !ok {
+		t.Error("VaultTokenStoreHoldoff assignment not made:  Key not present in Extras map")
+	}
+	if valBool, ok := val.(bool); !ok {
+		t.Error("Stored value failed type check")
+	} else if !valBool {
+		t.Error("Stored value should be true.  Got false instead")
+	}
+}
+
+func TestGetDefaultRoleFileDestinationTemplateValueFromExtras(t *testing.T) {
+	config, _ := NewConfig(service.NewService("test_service"), SetSupportedExtrasKeyValue(DefaultRoleFileDestinationTemplate, "foobar"))
+	val, ok := config.Extras[DefaultRoleFileDestinationTemplate]
+	if !ok {
+		t.Error("DefaultRoleFileDestinationTemplate assignment not made:  Key not present in Extras map")
+	}
+	if valString, ok := val.(string); !ok {
+		t.Error("Stored value failed type check")
+	} else if valString != "foobar" {
+		t.Errorf("Stored value should be foobar.  Got %s instead", valString)
+	}
+}


### PR DESCRIPTION
Closes #54 

This fixes the issue in the v0.9 series where concurrent `condor_vault_storer` calls from the same client for the same token encountered a race condition.