### PR TITLE
Control loki client timeout

### DIFF
--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -235,6 +235,19 @@ func initLogs() {
 	if viper.GetBool("no-loki") || viper.GetString("loki.host") == "" {
 		log.Info("Loki logging disabled by flag")
 	} else {
+		lokiClient := http.DefaultClient
+
+		var useTransport *http.Transport
+		_transport := http.DefaultTransport
+		if _val, ok := _transport.(*http.Transport); ok {
+			useTransport = _val.Clone()
+			// Since we can't directly pass a context into each request that lokirus makes, we
+			// set a timeout on how long each client request is allowed to take before we get
+			// the response headers back
+			useTransport.ResponseHeaderTimeout = 1 * time.Second
+			lokiClient.Transport = useTransport
+		}
+
 		lokiOpts := lokirus.NewLokiHookOptions().
 			// Grafana doesn't have a "panic" level, but it does have a "critical" level
 			// https://grafana.com/docs/grafana/latest/explore/logs-integration/
@@ -244,7 +257,8 @@ func initLogs() {
 				"app":         "managed-tokens",
 				"command":     currentExecutable,
 				"environment": devEnvironmentLabel,
-			})
+			}).
+			WithHttpClient(lokiClient)
 		lokiHook := lokirus.NewLokiHookWithOpts(
 			viper.GetString("loki.host"),
 			lokiOpts,

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -163,6 +163,7 @@ func initFlags() {
 	pflag.StringP("configfile", "c", "", "Specify alternate config file")
 	pflag.Bool("disable-notifications", false, "Do not send admin notifications")
 	pflag.Bool("dont-notify", false, "Same as --disable-notifications")
+	pflag.Bool("no-loki", false, "Disable sending logs to Loki (should only be used in testing or temporary debugging)")
 	pflag.BoolP("test", "t", false, "Test mode.  Query FERRY, but do not make any database changes")
 	pflag.BoolP("verbose", "v", false, "Turn on verbose mode")
 	pflag.Bool("version", false, "Version of Managed Tokens library")
@@ -231,25 +232,29 @@ func initLogs() {
 	}, &log.TextFormatter{FullTimestamp: true}))
 
 	// Loki.  Example here taken from README: https://github.com/YuKitsune/lokirus/blob/main/README.md
-	lokiOpts := lokirus.NewLokiHookOptions().
-		// Grafana doesn't have a "panic" level, but it does have a "critical" level
-		// https://grafana.com/docs/grafana/latest/explore/logs-integration/
-		WithLevelMap(lokirus.LevelMap{log.PanicLevel: "critical"}).
-		WithFormatter(&log.JSONFormatter{}).
-		WithStaticLabels(lokirus.Labels{
-			"app":         "managed-tokens",
-			"command":     currentExecutable,
-			"environment": devEnvironmentLabel,
-		})
-	lokiHook := lokirus.NewLokiHookWithOpts(
-		viper.GetString("loki.host"),
-		lokiOpts,
-		log.InfoLevel,
-		log.WarnLevel,
-		log.ErrorLevel,
-		log.FatalLevel)
+	if viper.GetBool("no-loki") || viper.GetString("loki.host") == "" {
+		log.Info("Loki logging disabled by flag")
+	} else {
+		lokiOpts := lokirus.NewLokiHookOptions().
+			// Grafana doesn't have a "panic" level, but it does have a "critical" level
+			// https://grafana.com/docs/grafana/latest/explore/logs-integration/
+			WithLevelMap(lokirus.LevelMap{log.PanicLevel: "critical"}).
+			WithFormatter(&log.JSONFormatter{}).
+			WithStaticLabels(lokirus.Labels{
+				"app":         "managed-tokens",
+				"command":     currentExecutable,
+				"environment": devEnvironmentLabel,
+			})
+		lokiHook := lokirus.NewLokiHookWithOpts(
+			viper.GetString("loki.host"),
+			lokiOpts,
+			log.InfoLevel,
+			log.WarnLevel,
+			log.ErrorLevel,
+			log.FatalLevel)
 
-	log.AddHook(lokiHook)
+		log.AddHook(lokiHook)
+	}
 
 	exeLogger = log.WithField("executable", currentExecutable)
 	exeLogger.Debugf("Using config file %s", viper.ConfigFileUsed())

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -237,6 +237,11 @@ func initLogs() {
 	} else {
 		lokiClient := http.DefaultClient
 
+		var lokiClientTimeout = 1 * time.Second
+		if _timeout, err := time.ParseDuration(viper.GetString("loki.response_header_timeout")); err == nil {
+			lokiClientTimeout = _timeout
+		}
+
 		var useTransport *http.Transport
 		_transport := http.DefaultTransport
 		if _val, ok := _transport.(*http.Transport); ok {
@@ -244,7 +249,7 @@ func initLogs() {
 			// Since we can't directly pass a context into each request that lokirus makes, we
 			// set a timeout on how long each client request is allowed to take before we get
 			// the response headers back
-			useTransport.ResponseHeaderTimeout = 1 * time.Second
+			useTransport.ResponseHeaderTimeout = lokiClientTimeout
 			lokiClient.Transport = useTransport
 		}
 

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -700,6 +700,11 @@ func initLogs() {
 	} else {
 		lokiClient := http.DefaultClient
 
+		var lokiClientTimeout = 1 * time.Second
+		if _timeout, err := time.ParseDuration(viper.GetString("loki.response_header_timeout")); err == nil {
+			lokiClientTimeout = _timeout
+		}
+
 		var useTransport *http.Transport
 		_transport := http.DefaultTransport
 		if _val, ok := _transport.(*http.Transport); ok {
@@ -707,7 +712,7 @@ func initLogs() {
 			// Since we can't directly pass a context into each request that lokirus makes, we
 			// set a timeout on how long each client request is allowed to take before we get
 			// the response headers back
-			useTransport.ResponseHeaderTimeout = 1 * time.Second
+			useTransport.ResponseHeaderTimeout = lokiClientTimeout
 			lokiClient.Transport = useTransport
 		}
 

--- a/libsonnet/observability.libsonnet
+++ b/libsonnet/observability.libsonnet
@@ -18,6 +18,7 @@
     # Loki settings
     loki: {
         host: "hostname.domain", # Required for loki use
+        response_header_timeout: "1s", # Timeout for HTTP responses from Loki for each request
     },
 
     # Tracing settings

--- a/managedTokens.json
+++ b/managedTokens.json
@@ -147,7 +147,8 @@
       }
    },
    "loki": {
-      "host": "hostname.domain"
+      "host": "hostname.domain",
+      "response_header_timeout": "1s"
    },
    "minTokenLifetime": "3d",
    "notifications": {


### PR DESCRIPTION
We ran into an issue yesterday where the production Loki instance was getting backed at ingest.  We patched the `token-push` executable to get it running again by bypassing the Loki hook here, but that was a temporary solution. 

This is the permanent solution, namely:

1. Add a `--no-loki` flag to both executables that allows us to bypass Loki logging altogether. (`cmd/token-push/main.go`, `cmd/refresh-uids-from-ferry/main.go`)
2. Add a configuration file field, `loki.response_header_timeout`, that controls what the timeout is for the executables to send logs to Loki (`libsonnet/observability.libsonnet`)
3. Have the executables look for the flag in (2), and if it's not there, use a default timeout of 1s. We introduce a custom `*http.Client` struct for the Loki logging that uses this timeout for how long it'll wait for response headers.  I figure if we're waiting longer than 1 s per batch, that's probably too long given how many log messages we're sending.

This PR will be merged into a new `v0.17-release` branch, which will be merged back into `main` after the new release is deployed.

All unit tests pass.