### PR TITLE
Fix jsonnet test from v0.17.1 change

### DIFF
--- a/managedTokens_test.jsonnet
+++ b/managedTokens_test.jsonnet
@@ -306,7 +306,8 @@ test.suite({
                 }
             },
             "loki": {
-                "host": "hostname.domain"
+                "host": "hostname.domain",
+                "response_header_timeout": "1s"
             },
             "minTokenLifetime": "3d",
             "notifications": {


### PR DESCRIPTION
In deploying v0.17.1, I forgot to update a jsonnet test to expect the new flag `response_header_timeout`. Fixed that here, and I reran the unit tests by hand to make sure it works.